### PR TITLE
Add 'list' position source

### DIFF
--- a/ptycho/+detector/+empad_lebeau/load_data.m
+++ b/ptycho/+detector/+empad_lebeau/load_data.m
@@ -42,6 +42,7 @@ if isfield(p.detector, 'crop') && ~isempty(p.detector.crop)
     nx = size(data, 3);
     ny = size(data, 4);
 
+    % TODO: crop position list as well
     if isfield(p, 'scan') && isfield(p.scan, 'type') && p.scan.type == "raster"
         positions = reshape(p.positions, p.scan.nx, p.scan.ny, 2);
         positions = positions(min_y:max_y, min_x:max_x, :);

--- a/ptycho/+scans/+positions/matlab_pos.m
+++ b/ptycho/+scans/+positions/matlab_pos.m
@@ -134,10 +134,23 @@ for ii = 1:p.numscans
             catch
                 error('Failed to load positions from %s', pos_file);
             end
+        
+        case 'list' % custom positions list stored in data
+            if isempty(p.scan.scan_positions) || ~ndims(p.scan.scan_positions)
+                error("scan_positions must be given as a list of probe positions");
+            end
+            positions_real = p.scan.scan_positions;
+            if size(positions_real, ndims(positions_real)) ~= 2
+                error("Invalid shape for scan_positions. Expected a shape of [Npos, 2]");
+            end
+            if ~ismatrix(positions_real)
+                % flatten 3D arrays into 2D
+                positions_real = reshape(positions_real, numel(positions_real) / 2, 2);
+            end
+            positions_real = flip(positions_real, 2); % flip [x, y] to [y, x]
         otherwise
             error('Unknown scan type %s.', p.scan.type);
     end
-    
     p.numpts(ii) = size(positions_real,1);
     p.positions_real = [p.positions_real ; positions_real];
 end


### PR DESCRIPTION
Adds a 'list' scan type which takes an explicit list of probe positions.

Also ensures coordinate systems are consistent in empad_lebeau's `load_data`, and that options `crop`, `step` and `tile` work as expected.